### PR TITLE
Fix - type select & select2

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -95,7 +95,7 @@ module X
           
           values = Array.wrap(value)
           
-          if source
+          if source && source.first.is_a?(String)
             values.map{|item| source[output_value_for item]}
           else
             values
@@ -130,6 +130,8 @@ module X
             when String
               if source.is_a?(Array) && source.first.is_a?(String)
                 source.inject({}){|hash, key| hash.merge(key => key)}
+              elsif source.is_a?(Hash)
+                source
               end
             end
           


### PR DESCRIPTION
Fix for type select & select2 to work.

``` ruby
%h1= editable @model, :name, type: :select, source: [{value: 1, text: 'Hello'}, {value: 2, text: 'World'}]
```

and

``` ruby
%h1= editable @model, :name, type: :select2, source: [{id: 1, text: 'Hello'}, {id: 2, text: 'World'}]
```
