### PR TITLE
Tag content only if type isn't select or checklist

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -63,7 +63,7 @@ module X
             data.reject!{|_, value| value.nil?}
             
             content_tag tag, class: css, title: title, data: data do
-              source_values_for(value, source).join('<br/>').html_safe
+              source_values_for(value, source).join('<br/>').html_safe if !["select","checklist"].include? data[:type]
             end
           else
             # create a friendly value using the source to display a default value (if no error message given)


### PR DESCRIPTION
For these types, xeditable handles the values for you

Solves issue #24, but perhaps not in the best way.
