### PR TITLE
Unsafe use of html_safe in ViewHelpers

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -28,6 +28,7 @@ module X
           source  = options[:source] ? format_source(options.delete(:source), value) : default_source_for(value)
           classes = format_source(options.delete(:classes), value)
           error   = options.delete(:e)
+          source_values = safe_join(source_values_for(value, source), tag(:br))
           
           if xeditable?(object)
             model   = object.class.name.split('::').last.underscore
@@ -63,11 +64,11 @@ module X
             data.reject!{|_, value| value.nil?}
             
             content_tag tag, class: css, title: title, data: data do
-              source_values_for(value, source).join('<br/>').html_safe
+              source_values
             end
           else
             # create a friendly value using the source to display a default value (if no error message given)
-            error || source_values_for(value, source).join('<br/>').html_safe
+            error || source_values
           end
         end
         
@@ -87,7 +88,7 @@ module X
             value.to_s
           end
           
-          value.html_safe
+          value
         end
         
         def source_values_for(value, source = nil)


### PR DESCRIPTION
I believe there are a few places in view_helper.rb (line 66, 70, and 90) where #html_safe is used on possibly unsanitary user-provided text.  It's not clear to me if this actually presents an XSS vulnerability, as some of those values are used as attributes to the tag helper, which presumably will do some escaping of its own.  It also depends on the `escape` option to the javascript plugin.

All the same, they look dangerous to me, so here's a proposed fix.  This should preserve the ability for values to have embedded HTML and turn off the jQuery plugin's escaping if you really really want.  These are untested as I'm just using the builtin GitHub editor.  [`safe_join`](http://apidock.com/rails/ActionView/Helpers/OutputSafetyHelper/safe_join) is an ActionView helper that simplifies joining potentially untrusted strings with a trusted (`<br />` in this case) separator.
