### PR TITLE
Removes unsafe use of `html_safe`.

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -16,19 +16,19 @@ module X
         #       - enumerable shorthand ['Yes', 'No', 'Maybe'] becomes { 'Yes' => 'Yes', 'No' => 'No', 'Maybe' => 'Maybe' }
         #     classes: a Hash of classes to add based on the value (same format and shorthands as source)
         #   value: override the object's value
-        #   
+        #
         def editable(object, method, options = {})
           options = Configuration.method_options_for(object, method).deep_merge(options).with_indifferent_access
           # merge data attributes for backwards-compatibility
           options.merge! options.delete(:data){ Hash.new }
-          
+
           url     = options.delete(:url){ polymorphic_path(object) }
           object  = object.last if object.kind_of?(Array)
           value   = options.delete(:value){ object.send(method) }
           source  = options[:source] ? format_source(options.delete(:source), value) : default_source_for(value)
           classes = format_source(options.delete(:classes), value)
           error   = options.delete(:e)
-          
+
           if xeditable?(object)
             model   = object.class.name.split('::').last.underscore
             nid     = options.delete(:nid)
@@ -37,42 +37,41 @@ module X
               klass = nested ? object.class.const_get(nested.to_s.singularize.capitalize) : object.class
               klass.human_attribute_name(method)
             end
-            
+
             output_value = output_value_for(value)
             css_list = options.delete(:class).to_s.split(/\s+/).unshift('editable')
             css_list << classes[output_value] if classes
-            
+
             css   = css_list.compact.uniq.join(' ')
             tag   = options.delete(:tag){ 'span' }
             placeholder = options.delete(:placeholder){ title }
-            
+
             # any remaining options become data attributes
             data  = {
-              type:   options.delete(:type){ default_type_for(value) }, 
-              model:  model, 
-              name:   method, 
-              value:  output_value, 
-              placeholder: placeholder, 
-              classes: classes, 
-              source: source, 
-              url:    url, 
-              nested: nested, 
+              type:   options.delete(:type){ default_type_for(value) },
+              model:  model,
+              name:   method,
+              value:  output_value,
+              placeholder: placeholder,
+              classes: classes,
+              source: source,
+              url:    url,
+              nested: nested,
               nid:    nid
             }.merge(options)
-            
+
             data.reject!{|_, value| value.nil?}
-            
+
             content_tag tag, class: css, title: title, data: data do
-              safe_join(source_values_for(value.try(:html_safe), source), tag(:br)) unless %w(select checklist).include? data[:type]
+              safe_join(source_values_for(value, source), tag(:br)) unless %w(select checklist).include? data[:type]
             end
           else
-            value = value.try(:html_safe) unless value.kind_of?(TrueClass) or value.kind_of?(FalseClass)
             error || safe_join(source_values_for(value, source), tag(:br))
           end
         end
-        
+
         private
-        
+
         def output_value_for(value)
           value = case value
           when TrueClass
@@ -86,22 +85,22 @@ module X
           else
             value.to_s
           end
-          
+
           value
         end
-        
+
         def source_values_for(value, source = nil)
           source ||= default_source_for value
-          
+
           values = Array.wrap(value)
-          
+
           if source && ( source.first.is_a?(String) || source.kind_of?(Hash) )
             values.map{|item| source[output_value_for item]}
           else
             values
           end
         end
-        
+
         def default_type_for(value)
           case value
           when TrueClass, FalseClass
@@ -112,14 +111,14 @@ module X
             'text'
           end
         end
-        
+
         def default_source_for(value)
           case value
           when TrueClass, FalseClass
             { '1' => 'Yes', '0' => 'No' }
           end
         end
-        
+
         # helper method that take some shorthand source definitions and reformats them
         def format_source(source, value)
           formatted_source = case value
@@ -134,10 +133,10 @@ module X
                 source
               end
             end
-          
+
           formatted_source || source
         end
-        
+
       end
     end
   end

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class ViewHelpersTest < ActionView::TestCase
+  include X::Editable::Rails::ViewHelpers
+
+  class Subject < OpenStruct
+    extend ActiveModel::Naming
+    extend ActiveModel::Translation
+
+    def initialize(attributes={})
+      super(attributes.merge(id: 1, name: "test subject"))
+    end
+
+    def to_param
+      "#{id}-#{name}".parameterize
+    end
+  end
+
+  test "editable should escape unsafe values" do
+    subject = Subject.new(content: "<h1>unsafe content</h1>")
+    assert_match %r{&lt;h1&gt;unsafe content&lt;/h1&gt;</span>},
+                 editable(subject, :content),
+                 "ViewHelpers#editable should escape unsafe content"
+  end
+
+  test "editable should NOT escape safe values" do
+    subject = Subject.new(content: "<h1>html_safe'd content</h1>".html_safe)
+    assert_match %r{<h1>html_safe'd content</h1></span>},
+                 editable(subject, :content),
+                 "ViewHelpers#editable should not escape safe content"
+
+    subject.content = "safe content"
+    assert_match %r{safe content</span>},
+                 editable(subject, :content),
+                 "ViewHelpers#editable should not escape safe content"
+  end
+
+  private
+
+  def view_helpers_test_subject_path(subject)
+    "/#{subject.to_param}"
+  end
+
+  def xeditable?(*args)
+    true
+  end
+end


### PR DESCRIPTION
Any user content (thus unknown) should not be `html_safe`'ed. The `html_safe` should be applied only by the data owner. Clients (like x-editable-rails) should never trust external data.

The issue can be seen here: https://github.com/werein/x-editable-rails/pull/30#issuecomment-46929420

User provided values that are already `html_safe`'ed are respected (as demonstrated by tests).

Fixes #30. This conflicts with #35.
