### PR TITLE
Feature: Enable customization of content tag with html options

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -16,19 +16,20 @@ module X
         #       - enumerable shorthand ['Yes', 'No', 'Maybe'] becomes { 'Yes' => 'Yes', 'No' => 'No', 'Maybe' => 'Maybe' }
         #     classes: a Hash of classes to add based on the value (same format and shorthands as source)
         #   value: override the object's value
-        #   
+        #
         def editable(object, method, options = {})
           options = Configuration.method_options_for(object, method).deep_merge(options).with_indifferent_access
           # merge data attributes for backwards-compatibility
           options.merge! options.delete(:data){ Hash.new }
-          
+
           url     = options.delete(:url){ polymorphic_path(object) }
           object  = object.last if object.kind_of?(Array)
           value   = options.delete(:value){ object.send(method) }
           source  = options[:source] ? format_source(options.delete(:source), value) : default_source_for(value)
           classes = format_source(options.delete(:classes), value)
           error   = options.delete(:e)
-          
+          html_options = options.delete(:html){ Hash.new }
+
           if xeditable?(object)
             model   = object.class.name.split('::').last.underscore
             nid     = options.delete(:nid)
@@ -37,32 +38,38 @@ module X
               klass = nested ? object.class.const_get(nested.to_s.singularize.capitalize) : object.class
               klass.human_attribute_name(method)
             end
-            
+
             output_value = output_value_for(value)
             css_list = options.delete(:class).to_s.split(/\s+/).unshift('editable')
             css_list << classes[output_value] if classes
-            
+
             css   = css_list.compact.uniq.join(' ')
             tag   = options.delete(:tag){ 'span' }
             placeholder = options.delete(:placeholder){ title }
-            
+
             # any remaining options become data attributes
             data  = {
-              type:   options.delete(:type){ default_type_for(value) }, 
-              model:  model, 
-              name:   method, 
-              value:  output_value, 
-              placeholder: placeholder, 
-              classes: classes, 
-              source: source, 
-              url:    url, 
-              nested: nested, 
+              type:   options.delete(:type){ default_type_for(value) },
+              model:  model,
+              name:   method,
+              value:  output_value,
+              placeholder: placeholder,
+              classes: classes,
+              source: source,
+              url:    url,
+              nested: nested,
               nid:    nid
             }.merge(options)
-            
+
             data.reject!{|_, value| value.nil?}
-            
-            content_tag tag, class: css, title: title, data: data do
+
+            html_options.update({
+              class: css,
+              title: title,
+              data: data
+            })
+
+            content_tag tag, html_options do
               safe_join(source_values_for(value.try(:html_safe), source), tag(:br)) unless %w(select checklist).include? data[:type]
             end
           else
@@ -70,9 +77,9 @@ module X
             error || safe_join(source_values_for(value, source), tag(:br))
           end
         end
-        
+
         private
-        
+
         def output_value_for(value)
           value = case value
           when TrueClass
@@ -86,22 +93,22 @@ module X
           else
             value.to_s
           end
-          
+
           value
         end
-        
+
         def source_values_for(value, source = nil)
           source ||= default_source_for value
-          
+
           values = Array.wrap(value)
-          
+
           if source && ( source.first.is_a?(String) || source.kind_of?(Hash) )
             values.map{|item| source[output_value_for item]}
           else
             values
           end
         end
-        
+
         def default_type_for(value)
           case value
           when TrueClass, FalseClass
@@ -112,14 +119,14 @@ module X
             'text'
           end
         end
-        
+
         def default_source_for(value)
           case value
           when TrueClass, FalseClass
             { '1' => 'Yes', '0' => 'No' }
           end
         end
-        
+
         # helper method that take some shorthand source definitions and reformats them
         def format_source(source, value)
           formatted_source = case value
@@ -134,10 +141,10 @@ module X
                 source
               end
             end
-          
+
           formatted_source || source
         end
-        
+
       end
     end
   end

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class ViewHelpersTest < ActionView::TestCase
+  include X::Editable::Rails::ViewHelpers
+
+  class Subject < OpenStruct
+    extend ActiveModel::Naming
+    extend ActiveModel::Translation
+
+    def initialize(attributes={})
+      super(attributes.merge(id: 1, name: "test subject"))
+    end
+
+    def to_param
+      "#{id}-#{name}".parameterize
+    end
+  end
+
+  test "editable should generate content tag with html options" do
+    subject = Subject.new
+
+    assert_match %r{<span[^>]+id="subject-id"},
+                 editable(subject, :name, html: { id: 'subject-id' }),
+                 "ViewHelpers#editable should generate content tag with html options"
+
+    assert_match %r{<span[^>]+name="subject\[name\]"},
+                 editable(subject, :name, html: { name: 'subject[name]' }),
+                 "ViewHelpers#editable should generate content tag with html options"
+
+    assert_match %r{<span[^>]+title="First Title"},
+                 editable(subject, :name, title: "First Title", html: { title: 'Second Title' }),
+                 "ViewHelpers#editable should generate content tag with html options"
+  end
+
+  private
+
+  def view_helpers_test_subject_path(subject)
+    "/#{subject.to_param}"
+  end
+
+  def xeditable?(*args)
+    true
+  end
+end


### PR DESCRIPTION
Currently it's not possible to specify custom HTML attributes for field's the content tag. For example:

``` erb
<%= editable(@article, :title, id: "my-custom-id") %>
```

will output:

``` html
<span class="editable" data-id="my-custom-id" data-model="article" data-name="title" data-placeholder="Title" data-type="text" data-url="/articles/1" data-value="My first article" title="Title">My first article</span>
```

This PR adds an `:html` option to the `editable` helper that can customize the content tag's HTML attributes. Like this:

``` erb
<%= editable(@article, :title, html: { id: "my-custom-id" }) %>
```

will output:

``` html
<span class="editable" id="my-custom-id" data-model="article" data-name="title" data-placeholder="Title" data-type="text" data-url="/articles/1" data-value="My first article" title="Title">My first article</span>
```
