### PR TITLE
base64-encode the content of the data-value attribute

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -55,7 +55,7 @@ module X
               type:   type, 
               model:  model, 
               name:   method, 
-              value:  ( type == 'wysihtml5' ? Base64.encode64(output_value) : output_value ), 
+              value:  ( type == 'wysihtml5' ? Base64.strict_encode64(output_value) : output_value ), 
               placeholder: placeholder, 
               classes: classes, 
               source: source, 

--- a/vendor/assets/javascripts/editable/inputs-ext/wysihtml5-editable.js
+++ b/vendor/assets/javascripts/editable/inputs-ext/wysihtml5-editable.js
@@ -85,9 +85,13 @@ $(function(){
         },
         
         value2input: function(value) {
-            value = (this.valueIsEncoded ? atob(value.replace(/\s/g, '')) : value)
+            value = (this.valueIsEncoded ? this.base65decode(value) : value);
             this.$input.data("wysihtml5").editor.setValue(value, true);
-        }, 
+        },
+
+        base65decode: function(value) {
+            return decodeURIComponent( escape( atob( value.replace(/\s/g, ''))));
+        },
 
         activate: function() {
             this.$input.data("wysihtml5").editor.focus();


### PR DESCRIPTION
base64-encode the content of the data-value attribute, if the type is wysihtml. This fixes a problem where links generated by wysihtml5 break the HTML. see https://github.com/werein/x-editable-rails/issues/42
