### PR TITLE
Guessing type from active record

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -83,7 +83,7 @@ module X
         private
 
         def output_value_for(value)
-          value = case value
+          case value
           when TrueClass
             '1'
           when FalseClass
@@ -95,8 +95,6 @@ module X
           else
             value.to_s
           end
-
-          value
         end
 
         def source_values_for(value, value_type, source = nil)


### PR DESCRIPTION
If you have an active record modell with an boolean column, but with an nil value it was not recognised as an boolean. So the x-editable is shown as string instead of boolean select. This is an fix for it.
