### PR TITLE
Update editable_form.js.coffee

### DIFF
--- a/vendor/assets/javascripts/editable/rails/editable_form.js.coffee
+++ b/vendor/assets/javascripts/editable/rails/editable_form.js.coffee
@@ -32,7 +32,8 @@ unless EditableForm
         else
           obj[myName] = myValue
 
-        params[model] = obj
+        params[model] ||= {}
+        $.extend(params[model], obj)
 
         delete params.name
         delete params.value


### PR DESCRIPTION
The model parameters generated by the gem no longer override the model parameters created by the user.

In my case I have a table displaying instances of WorklistItem and each cell is x-editable. I wanted to implement optimistic locking per row. To do this, I need to pass a parameter which looks like this: {worklist_item: {lock_version: 1}}. However, the gem overrides it in the EditableForm.saveWithUrlHook method.

This pull request fixes that.