### PR TITLE
Use `model_name` instead of inferring it from class name

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -33,7 +33,7 @@ module X
           html_options = options.delete(:html){ Hash.new }
 
           if xeditable?(object)
-            model   = object.class.name.split('::').last.underscore
+            model   = object.model_name.to_s.underscore
             nid     = options.delete(:nid)
             nested  = options.delete(:nested)
             title   = options.delete(:title) do


### PR DESCRIPTION
This allows the use of decorator pattern in views.