### PR TITLE
Add a more robust Travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea
 .DS_Store
 Gemfile.lock
+gemfiles/*.gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+branches: master
+cache: bundler
+gemfile:
+  - gemfiles/rails_4_0.gemfile
+  - gemfiles/rails_4_1.gemfile
+  - gemfiles/rails_4_2.gemfile
+language: ruby
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+rvm:
+  - "2.0"
+  - "2.1"
+  - "2.2"
+  - ruby-head
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in x-editable-rails.gemspec
 gemspec
-
-gem 'haml-rails'
-gem 'sass-rails'
-gem 'coffee-rails'
-gem 'jquery-rails'
-gem 'bootstrap-sass'
-gem 'globalize', '~> 4.0.0.alpha.2'

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.0.0'

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.1.0'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.2.0'


### PR DESCRIPTION
This builds the library against every combination of the following Ruby and Rails versions:

#### Ruby

* 2.0
* 2.1
* 2.2
* ruby-head

#### Rails

* 4.0
* 4.1
* 4.2

Travis failures are allowed on ruby-head but the build is still run for informational purposes.