### PR TITLE
Avoid duplicate data attributes due to string/symbol Hash keys

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -61,7 +61,7 @@ module X
               url:    url,
               nested: nested,
               nid:    nid
-            }.merge(options)
+            }.merge(options.symbolize_keys)
 
             data.reject!{|_, value| value.nil?}
 

--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -33,7 +33,7 @@ module X
           html_options = options.delete(:html){ Hash.new }
 
           if xeditable?(object)
-            model   = object.model_name.to_s.underscore
+            model   = object.class.model_name.element
             nid     = options.delete(:nid)
             nested  = options.delete(:nested)
             title   = options.delete(:title) do

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Dummy::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  # config.serve_static_assets = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,8 +13,8 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
-  config.static_cache_control = "public, max-age=3600"
+  # config.serve_static_assets  = true
+  # config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
@@ -33,4 +33,6 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  config.active_support.test_order = :random
 end

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -52,6 +52,14 @@ class ViewHelpersTest < ActionView::TestCase
                  "ViewHelpers#editable should generate content tag with html options"
   end
 
+  test "editable should generate content tag with data attributes" do
+    subject = Subject.new
+
+    assert_match %r{<span[^>]+data-model="page"},
+                 editable(subject, :name),
+                 "ViewHelpers#editable should generate content tag with html options"
+  end
+
   private
 
   def view_helpers_test_subject_path(subject)

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -4,15 +4,16 @@ class ViewHelpersTest < ActionView::TestCase
   include X::Editable::Rails::ViewHelpers
 
   class Subject < OpenStruct
-    extend ActiveModel::Naming
-    extend ActiveModel::Translation
+    include ActiveModel::Model
+
+    attr_accessor :id, :name, :content
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "Page")
+    end
 
     def initialize(attributes={})
       super(attributes.merge(id: 1, name: "test subject"))
-    end
-
-    def to_param
-      "#{id}-#{name}".parameterize
     end
   end
 

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -57,7 +57,11 @@ class ViewHelpersTest < ActionView::TestCase
 
     assert_match %r{<span[^>]+data-model="page"},
                  editable(subject, :name),
-                 "ViewHelpers#editable should generate content tag with html options"
+                 "ViewHelpers#editable should generate content tag with data attributes"
+
+    assert_no_match %r{<span[^>]+data-model="page"},
+                    editable(subject, :name, model: "custom"),
+                    "ViewHelpers#editable should generate content tag with data attributes"
   end
 
   private


### PR DESCRIPTION
When passing in a custom "model", duplicate data attributes are added to the resulting HTML tag, making it unpredictable as to which will be used.

Please review/merge #58 first.