### PR TITLE
Show current value for Selects or Checklists, if any.

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -73,8 +73,8 @@ module X
 
             content_tag tag, html_options do
               if %w(select checklist).include? data[:type].to_s
-                inner_content = source.to_a.find { |t| t[:value].to_i == value.to_i }
-                inner_content.present? ? inner_content[:text] : ""
+                content = source.detect { |t| t[:value].to_i == value.to_i }
+                content.present? ? content[:text] : ""
               else
                 safe_join(source_values_for(value, source), tag(:br))
               end


### PR DESCRIPTION
For rendering purposes it's useful for the generated tag to include the field's current value, before the javascript is active.