### PR TITLE
Fix to show values of booleans before javascript runs

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -73,8 +73,9 @@ module X
 
             content_tag tag, html_options do
               if %w(select checklist).include? data[:type].to_s
-                content = source.detect { |t| t[:value].to_i == value.to_i }
-                content.present? ? content[:text] : ""
+                source = normalize_source(source)
+                content = source.detect { |t| output_value == output_value_for(t[0]) }
+                content.present? ? content[1] : ""
               else
                 safe_join(source_values_for(value, source), tag(:br))
               end
@@ -85,6 +86,16 @@ module X
         end
 
         private
+
+        def normalize_source(source)
+          source.map do |el|
+            if el.is_a? Array
+              el
+            else
+              [el[:value], el[:text]]
+            end
+          end
+        end
 
         def output_value_for(value)
           value = case value

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -6,7 +6,7 @@ class ViewHelpersTest < ActionView::TestCase
   class Subject < OpenStruct
     include ActiveModel::Model
 
-    attr_accessor :id, :name, :content
+    attr_accessor :id, :name, :content, :active
 
     def self.model_name
       ActiveModel::Name.new(self, nil, "Page")
@@ -62,6 +62,36 @@ class ViewHelpersTest < ActionView::TestCase
     assert_no_match %r{<span[^>]+data-model="page"},
                     editable(subject, :name, model: "custom"),
                     "ViewHelpers#editable should generate content tag with data attributes"
+  end
+
+  test "editable should generate content tag with the current value" do
+    subject_1 = Subject.new(content: "foo")
+
+    assert_match %r{<span[^>]+>foo</span>},
+                 editable(subject_1, :content),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+>foo</span>},
+                 editable(subject_1, :content, type: "select", source: ["foo", "bar"]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+>Foo</span>},
+                 editable(subject_1, :content, type: "select", source: [["foo", "Foo"], ["bar", "Bar"]]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+>Foo</span>},
+                 editable(subject_1, :content, type: "select", source: { "foo" => "Foo", "bar" => "Bar" }),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+>Foo</span>},
+                 editable(subject_1, :content, type: "select", source: [{ text: "Foo", value: "foo" }, { text: "Bar", value: "bar" }]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    subject_2 = Subject.new(active: true)
+
+    assert_match %r{<span[^>]+>Yes</span>},
+                 editable(subject_2, :active),
+                 "ViewHelpers#editable should generate content tag with the current value"
   end
 
   private


### PR DESCRIPTION
https://github.com/werein/x-editable-rails/pull/62 Blew up when using editable on a boolean attribute.
This fixes that, and includes tests to make sure it's working as expected.