### PR TITLE
Support for select dropdown array format (rebased)

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -121,6 +121,11 @@ module X
 
           if source && ( source.first.is_a?(String) || source.kind_of?(Hash) )
             values.map{|item| source[output_value_for item]}
+          elsif source && source.first.is_a?(Hash)
+            # Support for select dropdown array format
+            output_value = output_value_for(value)
+            value = source.flat_map { |e| e[:children] || e }.detect { |c| c[:value].to_s == output_value }.try { |e| e[:text] }
+            value ? [value] : values
           else
             values
           end


### PR DESCRIPTION
X-editable supports an array format for select controls in addition to the hash format already supported by this plugin.
This allows specifying a source that matches the array format and having the control use the proper text inside the HTML element.  The array format allows specifying list order in addition to optgroups.

https://vitalets.github.io/x-editable/docs.html under select then source

Needed to revert my master branch and rebase on new branch as new versions have broken our use.