### PR TITLE
Should use param_key for proper choice of the model parameter

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -33,7 +33,7 @@ module X
           html_options = options.delete(:html){ Hash.new }
 
           if xeditable?(object)
-            model   = object.class.model_name.element
+            model   = object.class.model_name.param_key
             nid     = options.delete(:nid)
             nested  = options.delete(:nested)
             title   = options.delete(:title) do


### PR DESCRIPTION
The name that should be used for the object parameters array should come from `param_key`.

(https://github.com/rails/rails/blob/9f44aa08636dfbba9261f4350ec14684425c4b7b/actionview/lib/action_view/helpers/form_helper.rb#L433)