### PR TITLE
Don't try to map Strings

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -72,7 +72,7 @@ module X
             })
 
             content_tag tag, html_options do
-              if %w(select checklist).include? data[:type].to_s
+              if %w(select checklist).include?(data[:type].to_s) && !source.is_a?(String)
                 source = normalize_source(source)
                 content = source.detect { |t| output_value == output_value_for(t[0]) }
                 content.present? ? content[1] : ""

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -94,6 +94,14 @@ class ViewHelpersTest < ActionView::TestCase
                  "ViewHelpers#editable should generate content tag with the current value"
   end
 
+  test "editable should store the source url as a data attribute" do
+    subject = Subject.new
+    assert_match %r{<span[^>]+data-source="http://example.org"},
+                 editable(subject, :name, type: "select",
+                 source: "http://example.org"),
+                 "ViewHelpers#editable should generate content tag with url source as a data attribute"
+  end
+
   private
 
   def view_helpers_test_subject_path(subject)


### PR DESCRIPTION
Trying to map ajax data sources for selects blows up. If the select's source is a String instead of a hash or array, don't map it.