### PR TITLE
Fix regressed handling of null values and no source for selects

### DIFF
--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -152,11 +152,9 @@ module X
               if source.is_a?(Array) && source.first.is_a?(String) && source.size == 2
                 { '1' => source[0], '0' => source[1] }
               end
-            when String
+            else
               if source.is_a?(Array) && source.first.is_a?(String)
-                source.inject({}){|hash, key| hash.merge(key => key)}
-              elsif source.is_a?(Hash)
-                source
+                source.map { |v| { value: v, text: v } }
               end
             end
 

--- a/lib/x-editable-rails/view_helpers.rb
+++ b/lib/x-editable-rails/view_helpers.rb
@@ -88,6 +88,7 @@ module X
         private
 
         def normalize_source(source)
+          return [] unless source
           source.map do |el|
             if el.is_a? Array
               el

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -87,6 +87,10 @@ class ViewHelpersTest < ActionView::TestCase
                  editable(subject_1, :content, type: "select", source: [{ text: "Foo", value: "foo" }, { text: "Bar", value: "bar" }]),
                  "ViewHelpers#editable should generate content tag with the current value"
 
+    refute_match %r{data-source=},
+                 editable(subject_1, :content, type: "select"),
+                 "ViewHelpers#editable should generate content tag without source"
+
     subject_2 = Subject.new(active: true)
 
     assert_match %r{<span[^>]+>Yes</span>},

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -106,6 +106,30 @@ class ViewHelpersTest < ActionView::TestCase
                  "ViewHelpers#editable should generate content tag with url source as a data attribute"
   end
 
+  test "editable should generate content tag without current value" do
+    subject_1 = Subject.new(content: nil)
+
+    assert_match %r{<span[^>]+></span>},
+                 editable(subject_1, :content),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+></span>},
+                 editable(subject_1, :content, type: "select", source: ["foo", "bar"]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+></span>},
+                 editable(subject_1, :content, type: "select", source: [["foo", "Foo"], ["bar", "Bar"]]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+></span>},
+                 editable(subject_1, :content, type: "select", source: { "foo" => "Foo", "bar" => "Bar" }),
+                 "ViewHelpers#editable should generate content tag with the current value"
+
+    assert_match %r{<span[^>]+></span>},
+                 editable(subject_1, :content, type: "select", source: [{ text: "Foo", value: "foo" }, { text: "Bar", value: "bar" }]),
+                 "ViewHelpers#editable should generate content tag with the current value"
+  end
+
   private
 
   def view_helpers_test_subject_path(subject)


### PR DESCRIPTION
Commit https://github.com/werein/x-editable-rails/commit/e63404057b47bf147459ba21bc0b8be9247fa511 cause a regression from the tagged v1.5.5 when handling select editables where either the source is not provided or the value is nil.

This changes format_source to work when the value is nil and use the newer { value: ..., text: ... } format instead of the hash format as that preserves the array ordering.
https://vitalets.github.io/x-editable/docs.html#select

Some test were added that fail before this change.