### PR TITLE
In order to avoid conflicts with other libraries, assigning $ with jQuery

### DIFF
--- a/vendor/assets/javascripts/editable/rails/editable_form.js.coffee
+++ b/vendor/assets/javascripts/editable/rails/editable_form.js.coffee
@@ -1,4 +1,5 @@
 unless EditableForm
+  $ = jQuery
   EditableForm = $.fn.editableform.Constructor
   EditableForm.prototype.saveWithUrlHook = (value) ->
     originalUrl   = @options.url

--- a/vendor/assets/javascripts/editable/rails/error_handling.js.coffee
+++ b/vendor/assets/javascripts/editable/rails/error_handling.js.coffee
@@ -1,3 +1,4 @@
+$ = jQuery
 $.fn.editable.defaults.error = (response, newValue) ->
   field_name = $(this).data("name")
   error_msgs = response.responseJSON.errors[field_name]


### PR DESCRIPTION
The rails coffescripts for editable_form and error_handling were compiling with a global use of the $ shortcut which can conflict with other libraries that could be included in an application.  By assigning the $ = jQuery, a var will be defined scoped to the function generated by compiling the coffee scripts.  This will allow for the functions to use $ internally as jQuery.

For example, if prototype is included, this avoids the two following errors on initialization of the page:

  editable_form.js?body=1:5 Uncaught TypeError: Cannot read property 'editableform' of undefined
      at editable_form.js?body=1:5
      at editable_form.js?body=1:55

and

  error_handling.js?body=1:2 Uncaught TypeError: Cannot read property 'editable' of undefined
      at error_handling.js?body=1:2
      at error_handling.js?body=1:9